### PR TITLE
Adds support for sessionless Gapcha

### DIFF
--- a/conf/tld/infoglue-common.tld
+++ b/conf/tld/infoglue-common.tld
@@ -1096,6 +1096,33 @@
 	</tag>
 	
 	<tag>
+		<name>verifyGapcha</name>
+		<tagclass>org.infoglue.deliver.taglib.common.VerifyGapchaTag</tagclass>
+		<bodycontent>empty</bodycontent>
+		<info></info>
+		<attribute>
+			<name>id</name>
+			<required>true</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>ticket</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>value</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>password</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	
+	<tag>
 	    <name>gapcha</name>
 	    <tagclass>org.infoglue.deliver.taglib.common.GapchaTag</tagclass>
 	    <bodycontent>empty</bodycontent>
@@ -1227,6 +1254,16 @@
         </attribute>
         <attribute>
             <name>allowedCharacters</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>ticket</name>
+            <required>false</required>
+            <rtexprvalue>false</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>password</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>

--- a/src/java/org/infoglue/deliver/taglib/common/GapchaTag.java
+++ b/src/java/org/infoglue/deliver/taglib/common/GapchaTag.java
@@ -24,13 +24,21 @@
 package org.infoglue.deliver.taglib.common;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
 import java.util.Random;
 
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
 import javax.servlet.jsp.JspException;
 
+import org.apache.axis.encoding.Base64;
 import org.apache.log4j.Logger;
 import org.infoglue.cms.util.CmsPropertyHandler;
-import org.infoglue.deliver.controllers.kernel.impl.simple.BasicTemplateController;
 
 /**
  * A Tag used for rendering distorted images with random text.  
@@ -50,6 +58,17 @@ public class GapchaTag extends TextRenderTag
 	private String textVariableName = "CAPTHCA_TEXT";
 	private int numberOfCharacters = 5;
 	private static int requestsNO = 0;
+	/** If set this value will be interpreted as a variable name to store the Captcha instance ticket.
+	 * If this value is set the tag will not store the Captcha ticket in the sessions. That means that
+	 * the tag caller has to handle the ticket and pass it with the form submit. */
+	private String ticket;
+
+	private static final String DEFAULT_PASSWORD = "TOPSECRETPASSWORDTHATNOONEKNOWS";
+	private String password ;
+	private static final byte[] SALT = {
+		(byte) 0xde, (byte) 0x73, (byte) 0x10, (byte) 0xa2,
+		(byte) 0xde, (byte) 0x73, (byte) 0x10, (byte) 0xa2,
+	};
 	
 	public GapchaTag() 
 	{
@@ -66,10 +85,28 @@ public class GapchaTag extends TextRenderTag
 		
 		// create the random string
 		char[] randomCharacters = createRandomCharacters();
+		if (ticket == null)
+		{
+			logger.info("Generating Gaptcha with session stored verification");
+			String sessionVariableName = textVariableName + "_" + System.currentTimeMillis();
+			pageContext.getSession().setAttribute( sessionVariableName, new String(randomCharacters) );
+			pageContext.setAttribute(textVariableName, sessionVariableName);
+		}
+		else
+		{
+			try
+			{
+				logger.info("Generating Gaptcha with encoded ticket");
+				pageContext.setAttribute(ticket, encodeTicket(new String(randomCharacters)));
+			}
+			catch (Exception ex)
+			{
+				logger.error("Error generating encrypted ticket for Gapcha. Message: " + ex.getMessage());
+				logger.warn("Error generating encrypted ticket for Gapcha.", ex);
+				throw new JspException("Error generating captcha");
+			}
+		}
 		// set the random string in the session
-		String sessionVariableName = textVariableName + "_" + System.currentTimeMillis();
-		pageContext.getSession().setAttribute( sessionVariableName, new String(randomCharacters) );
-		pageContext.setAttribute(textVariableName, sessionVariableName);
 		// without spacing it is really hard to read the text
 		String randomText = spaceCharacters(randomCharacters);
 		try 
@@ -86,7 +123,33 @@ public class GapchaTag extends TextRenderTag
 		
 		return EVAL_PAGE;
 	}
+
+	private String encodeTicket(String characters) throws GeneralSecurityException, UnsupportedEncodingException
+	{
+		if (password == null)
+		{
+			password = DEFAULT_PASSWORD;
+		}
+		SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+		SecretKey key = keyFactory.generateSecret(new PBEKeySpec(password.toCharArray()));
+		Cipher pbeCipher = Cipher.getInstance("PBEWithMD5AndDES");
+		pbeCipher.init(Cipher.ENCRYPT_MODE, key, new PBEParameterSpec(SALT, 20));
+		return Base64.encode(pbeCipher.doFinal(characters.getBytes("UTF-8")));
+	}
 	
+	/* default */ static String decodeTicket(String ticket, String password) throws GeneralSecurityException, IOException
+	{
+		if (password == null)
+		{
+			password = DEFAULT_PASSWORD;
+		}
+		SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+		SecretKey key = keyFactory.generateSecret(new PBEKeySpec(password.toCharArray()));
+		Cipher pbeCipher = Cipher.getInstance("PBEWithMD5AndDES");
+		pbeCipher.init(Cipher.DECRYPT_MODE, key, new PBEParameterSpec(SALT, 20));
+		return new String(pbeCipher.doFinal(Base64.decode(ticket)), "UTF-8");
+	}
+
 	public static void cleanOldFiles()
 	{
 		int i = 0;
@@ -146,7 +209,6 @@ public class GapchaTag extends TextRenderTag
 	private char[] createRandomCharacters()
 	{
 		Random r = new Random();
-		StringBuffer sb = new StringBuffer();
 		char[] buf = new char[numberOfCharacters];
 		for (int i = 0; i < buf.length; i++) 
 		{
@@ -200,4 +262,29 @@ public class GapchaTag extends TextRenderTag
 	{
 		this.allowedCharacters = evaluateString("gapcha", "allowedCharacters", allowedCharacters);
 	}
+
+	public void setTicket(String ticket)
+	{
+		this.ticket = ticket;
+	}
+
+	public void setPassword(String password) throws JspException
+	{
+		this.password = evaluateString("gapcha", "password", password);
+	}
+
+	public static void main(String[] args) throws UnsupportedEncodingException, GeneralSecurityException, IOException
+	{
+		System.out.println("Begin");
+		GapchaTag tag = new GapchaTag();
+		String enc1 = tag.encodeTicket("apa");
+		System.out.println("Test 1: apa = " + GapchaTag.decodeTicket(enc1, null) + " || " + enc1);
+		String enc2 = tag.encodeTicket("bepa123");
+		System.out.println("Test 2: bepa123 = " + GapchaTag.decodeTicket(enc2, null) + " || " + enc2);
+		
+		System.out.println("Test 3: ? = " + GapchaTag.decodeTicket("Bfck1bYW8r4=", null));
+		
+		System.out.println("End");
+	}
+
 }

--- a/src/java/org/infoglue/deliver/taglib/common/VerifyGapchaTag.java
+++ b/src/java/org/infoglue/deliver/taglib/common/VerifyGapchaTag.java
@@ -1,0 +1,88 @@
+/* ===============================================================================
+ *
+ * Part of the InfoGlue Content Management Platform (www.infoglue.org)
+ *
+ * ===============================================================================
+ *
+ *  Copyright (C)
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2, as published by the
+ * Free Software Foundation. See the file LICENSE.html for more information.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, including the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc. / 59 Temple
+ * Place, Suite 330 / Boston, MA 02111-1307 / USA.
+ *
+ * ===============================================================================
+ */
+
+package org.infoglue.deliver.taglib.common;
+
+import javax.crypto.BadPaddingException;
+import javax.servlet.jsp.JspException;
+
+import org.apache.log4j.Logger;
+
+public class VerifyGapchaTag extends TextRenderTag 
+{
+	private final static Logger logger = Logger.getLogger(VerifyGapchaTag.class.getName());
+	private static final long serialVersionUID = 867587689654L;
+
+	private String ticket;
+	private String value;
+	private String password;
+
+	private boolean verifyValue(String ticket, String value, String password) throws JspException
+	{
+		try
+		{
+			if (logger.isDebugEnabled())
+			{
+				logger.debug("Verify Gapcha: ticket: " + ticket + ", value: " + value + ", password: " + password);
+			}
+			String verificationValue = GapchaTag.decodeTicket(ticket, password);
+			return verificationValue.equalsIgnoreCase(value);
+		}
+		catch (Exception ex)
+		{
+			logger.error("Error when verifying gapcha. Message: " + ex.getMessage());
+			logger.warn("Error when verifying gapcha.", ex);
+			if (ex instanceof BadPaddingException)
+			{
+				throw new JspException("Failed to verify Captcha. Are you using the correct password (the one used to encrypt the ticket)?");
+			}
+			else
+			{
+				throw new JspException("Failed to verify Captcha");
+			}
+		}
+	}
+
+	public int doEndTag() throws JspException
+	{
+		setResultAttribute(verifyValue(ticket, value, password));
+
+		return EVAL_PAGE;
+	}
+
+	public void setTicket(String ticket) throws JspException
+	{
+		this.ticket = evaluateString("gapcha", "ticket", ticket);;
+	}
+
+	public void setValue(String value) throws JspException
+	{
+		this.value = evaluateString("gapcha", "value", value);
+	}
+
+	public void setPassword(String password) throws JspException
+	{
+		this.password = evaluateString("gapcha", "password", password);
+	}
+
+}


### PR DESCRIPTION
The current Gapcha implementation depends on a session variable.
If the server configuration does not allow uses to keep session
variables this solution will not work. Therefore has this new
alternative implementation been made. It returns an encrypted
value to the component that shall be passed with the request and
then validated in the receiving page.
