### PR TITLE
Adds a general settings field in app. settings

### DIFF
--- a/conf/tld/infoglue-management.tld
+++ b/conf/tld/infoglue-management.tld
@@ -1034,4 +1034,26 @@
             <rtexprvalue>false</rtexprvalue>
         </attribute>
 	</tag>
+
+	<tag>
+		<name>generalSetting</name>
+		<tagclass>org.infoglue.deliver.taglib.management.GeneralSettingTag</tagclass>
+		<bodycontent>empty</bodycontent>
+		<info>Gets a value from the general settings. TemplateController#getGeneralSetting()</info>
+		<attribute>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>key</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>default</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
 </taglib>

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
@@ -1589,3 +1589,6 @@ tool.mydesktoptool.workflow.invalidAction.message=The action you are trying to p
 tool.mydesktoptool.workflow.invalidAction.chooseActionMessage=Please select an action below to continue.
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.blank=Use blank as default
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.firstKey=Use first key as default
+
+entity.ServerNode.property.generalSettings.label=Custom settings that are defined for the entire application. See Java's documentation of the Properties class for formatting information.
+entity.ServerNode.property.workingGeneralSettings.label=Complementing custom settings that are only enabled in working mode (deliverWorking). Overwrites settings with the same keys in the main list.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
@@ -1763,3 +1763,6 @@ tool.mydesktoptool.workflow.invalidAction.message=The action you are trying to p
 tool.mydesktoptool.workflow.invalidAction.chooseActionMessage=Please select an action below to continue.
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.blank=Use blank as default
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.firstKey=Use first key as default
+
+entity.ServerNode.property.generalSettings.label=Custom settings that are defined for the entire application. See Java's documentation of the Properties class for formatting information.
+entity.ServerNode.property.workingGeneralSettings.label=Complementing custom settings that are only enabled in working mode (deliverWorking). Overwrites settings with the same keys in the main list.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
@@ -1566,3 +1566,6 @@ tool.mydesktoptool.workflow.invalidAction.message=Operationen du försökte utföra
 tool.mydesktoptool.workflow.invalidAction.chooseActionMessage=Välj en operation nedan för att fortsätta.
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.blank=Använd tom nyckel som standard
 tool.managementtool.viewContentTypeDefinition.defaultAssetKey.firstKey=Använda första nyckel som standard
+
+entity.ServerNode.property.generalSettings.label=Egendefinierade inställningar som är globala för hela applikationen. Se Java:s dokumentation av Properties för formateringsinformation.
+entity.ServerNode.property.workingGeneralSettings.label=Kompletterande egendefinierade inställningar som enbart gäller i arbetsläge (deliverWorking). Skriver över inställningar med samma nyckel från den allmänna listan.

--- a/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
+++ b/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
@@ -139,6 +139,8 @@ public class ViewServerNodePropertiesAction extends InfoGluePropertiesAbstractAc
 	    populate(ps, "pageKey");
 	    populate(ps, "componentKey");
 	    populateData(ps, "cacheSettings");
+	    populateData(ps, "generalSettings");
+	    populateData(ps, "workingGeneralSettings");
 	    populateData(ps, "extraPublicationPersistentCacheNames");
 	    populate(ps, "cmsBaseUrl");
 	    populate(ps, "cmsFullBaseUrl");

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/BasicTemplateController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/BasicTemplateController.java
@@ -46,6 +46,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
@@ -63,7 +64,6 @@ import org.apache.oro.text.regex.Perl5Compiler;
 import org.apache.oro.text.regex.Perl5Matcher;
 import org.exolab.castor.jdo.Database;
 import org.infoglue.cms.applications.common.VisualFormatter;
-import org.infoglue.cms.applications.databeans.ReferenceBean;
 import org.infoglue.cms.controllers.kernel.impl.simple.AccessRightController;
 import org.infoglue.cms.controllers.kernel.impl.simple.CastorDatabaseService;
 import org.infoglue.cms.controllers.kernel.impl.simple.CategoryConditions;
@@ -91,10 +91,8 @@ import org.infoglue.cms.entities.content.ContentVersionVO;
 import org.infoglue.cms.entities.content.DigitalAssetVO;
 import org.infoglue.cms.entities.management.ContentTypeAttribute;
 import org.infoglue.cms.entities.management.ContentTypeDefinitionVO;
-import org.infoglue.cms.entities.management.InterceptionPointVO;
 import org.infoglue.cms.entities.management.LanguageVO;
 import org.infoglue.cms.entities.management.RepositoryVO;
-import org.infoglue.cms.entities.structure.SiteNode;
 import org.infoglue.cms.entities.structure.SiteNodeVO;
 import org.infoglue.cms.entities.structure.SiteNodeVersionVO;
 import org.infoglue.cms.exception.SystemException;
@@ -8416,4 +8414,24 @@ public class BasicTemplateController implements TemplateController
     {
         return ( this instanceof EditOnSiteBasicTemplateController );
     }
+
+	public String getGeneralSetting(String key)
+	{
+		return getGeneralSetting(key, null);
+	}
+
+	public String getGeneralSetting(String key, String defaultValue)
+	{
+		Properties generalSettings = CmsPropertyHandler.getGeneralSettings(false);
+		String value = null;
+		if (generalSettings != null)
+		{
+			value = generalSettings.getProperty(key, defaultValue);
+		}
+		if (logger.isDebugEnabled())
+		{
+			logger.debug("Returning value <" + value + "> for general setting key <" + key + ">");
+		}
+		return value;
+	}
 }

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/TemplateController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/TemplateController.java
@@ -53,6 +53,7 @@ import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.security.InfoGlueGroup;
 import org.infoglue.cms.security.InfoGluePrincipal;
 import org.infoglue.cms.security.InfoGlueRole;
+import org.infoglue.cms.util.CmsPropertyHandler;
 import org.infoglue.cms.util.DesEncryptionHelper;
 import org.infoglue.cms.util.DocumentConverterHelper;
 import org.infoglue.deliver.applications.databeans.DatabaseWrapper;
@@ -1772,5 +1773,24 @@ public interface TemplateController
      * @return true if the pagenode is rendered with EditOnSight decoration.
      */
     public boolean getIsDecorated();
+
+	/**
+	 * Gets the value for the given <em>key</em> from the general settings. If the key is not
+	 * present in the settings null is returned.
+	 * @param key A key that should match a property in the general settings.
+	 * @return The value corresponding to the given key, or null of the key is not present.
+	 * @see CmsPropertyHandler#getGeneralSettings(boolean)
+	 */
+	public String getGeneralSetting(String key);
+
+	/**
+	 * Gets the value for the given <em>key</em> from the general settings. If the key is not
+	 * present in the settings <em>defaultValue</em> is returned.
+	 * @param key A key that should match a property in the general settings.
+	 * @param defaultValue If no value is found for the given key this value is returned.
+	 * @return The value corresponding to the given key, or null of the key is not present.
+	 * @see CmsPropertyHandler#getGeneralSettings(boolean)
+	 */
+	public String getGeneralSetting(String key, String defaultValue);
 
 }

--- a/src/java/org/infoglue/deliver/taglib/management/GeneralSettingTag.java
+++ b/src/java/org/infoglue/deliver/taglib/management/GeneralSettingTag.java
@@ -1,0 +1,42 @@
+package org.infoglue.deliver.taglib.management;
+
+import javax.servlet.jsp.JspException;
+
+import org.apache.log4j.Logger;
+import org.infoglue.deliver.controllers.kernel.impl.simple.TemplateController;
+import org.infoglue.deliver.taglib.TemplateControllerTag;
+
+public class GeneralSettingTag extends TemplateControllerTag
+{
+	private static final long serialVersionUID = 774587456364945754L;
+	private static final Logger logger = Logger.getLogger(GeneralSettingTag.class);
+
+	private String key;
+	private String defaultValue;
+
+	@Override
+	public int doEndTag() throws JspException
+	{
+		TemplateController tc = getController();
+		if (logger.isInfoEnabled())
+		{
+			logger.info("Getting value for key <" + key + ">. SiteNode.id: " + tc.getSiteNodeId() + ". Component.id: " + tc.getComponentContentId());
+		}
+
+		produceResult(tc.getGeneralSetting(key, defaultValue));
+
+		this.key = null;
+		this.defaultValue = null;
+		return EVAL_PAGE;
+	}
+
+	public void setKey(String key) throws JspException
+	{
+		this.key = evaluateString("GeneralSettingTag", "key", key);
+	}
+
+	public void setDefault(String defaultValue) throws JspException
+	{
+		this.defaultValue = evaluateString("GeneralSettingTag", "defaultValue", defaultValue);
+	}
+}

--- a/src/webapp/cms/managementtool/viewServerNodeProperties.vm
+++ b/src/webapp/cms/managementtool/viewServerNodeProperties.vm
@@ -237,7 +237,9 @@
 			#selectFieldCSS("ServerNode.property.minimumTimeBetweenVersionsDuringClean" "minimumTimeBetweenVersionsDuringClean" $this.getPropertyValue('minimumTimeBetweenVersionsDuringClean') $minimumTimeBetweenVersionsDuringCleanOptions)
 			#yesNoDropDownWithInheritCSS("ServerNode.property.duplicateAssetsBetweenVersions" "duplicateAssetsBetweenVersions" "$this.getPropertyValue('duplicateAssetsBetweenVersions')")
 			#editPropertyTextAreaCSS("ServerNode.property.assetUploadTransformationsSettings" "assetUploadTransformationsSettings" "$this.getDataPropertyValue('assetUploadTransformationsSettings')" "40" "6" "righttextarea" "$!serverNodeId")
-			
+			#editPropertyTextAreaCSS("ServerNode.property.generalSettings" "generalSettings" "$this.getDataPropertyValue('generalSettings')" "40" "6" "righttextarea" "$!serverNodeId")
+			#editPropertyTextAreaCSS("ServerNode.property.workingGeneralSettings" "workingGeneralSettings" "$this.getDataPropertyValue('workingGeneralSettings')" "40" "6" "righttextarea" "$!serverNodeId")
+
 			<div class="buttonRow">
 				<input type="image" src="$ui.getString("images.managementtool.buttons.save")" width="50" height="25" style="width: 50px;">
 				<a href="javascript:saveAndExit(document.editForm, 'ViewServerNodeProperties!saveAndExit.action');"><img src="$ui.getString("images.managementtool.buttons.saveAndExit")" width="80" height="25" border="0"></a>


### PR DESCRIPTION
The general settings is a way for the CMS users to specify application
wide settings. The settings can be read through the TemplateController
or using the the new tag management:generalSetting.

The values in the new property-set is defined using two fields. The first
is the primary field and is used like any other Properties-textare combo.
The second field however is only used when in working-mode and overrides
settings in the first field if they share keys. This enables the user to
disable or change features when in working-mode.
