### PR TITLE
Fixes a problem where the main frame was renamed

### DIFF
--- a/src/webapp/cms/contenttool/viewContentVersionForFCKEditor.vm
+++ b/src/webapp/cms/contenttool/viewContentVersionForFCKEditor.vm
@@ -14,14 +14,13 @@
 	<script type="text/javascript" src="${root}/applications/FCKEditor/fckeditor.js"></script>
 	<script type="text/javascript" src="${root}/script/v3/infoglueWidgets.js"></script>
 	<script type="text/javascript" src="${root}/script/v3/infoglueFormUtilities.js"></script>
-	<link rel="stylesheet" type="text/css" href="${root}/css/v3/infoglueWidgets.css" /> 
+	<link rel="stylesheet" type="text/css" href="${root}/css/v3/infoglueWidgets.css" />
 	
 	<script type="text/javascript">
-				
 		#if($syncAuto == "true")
 		syncWithTree();
 		#end
-	
+
 		
 		function hotkeyS()
 		{
@@ -314,7 +313,7 @@
 	var repositoryId 		= "$repositoryId";
 	var contentId 			= "$contentId";
 	var languageId 			= "$languageId";
-	var name 				= "$formatter.cleanForJavascriptStrings($name)";
+	var contentName			= "$formatter.cleanForJavascriptStrings($name)";
 	var contentTypeDefinitionName = "$contentTypeDefinitionName";
 	
 	var count = 0;


### PR DESCRIPTION
In the content view a variabel called 'name' was defined in the global
scope. In modern browsers this caused the frame to be renamed according to
the value of the variabel. Which in turn caused other operations to be
unable to locate the main frame. The variable is now renamed.
